### PR TITLE
Add bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:latest
 
+RUN apk --no-cache add bash
+
 # Only need ca-certificates & openssl if want to use DNS over TLS (RFC 7858).
 RUN apk --no-cache add bind-tools ca-certificates openssl && update-ca-certificates
 


### PR DESCRIPTION
Add bash to allow for users to easily access a running coredns container to inspect things like /etc/resolv.conf and /etc/hosts. It is currently infeasible to inspect /etc/resolv.conf to see upstream dns to troubleshoot.

<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
Add bash to the container

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None
